### PR TITLE
Custom player name and SkinsRestorer integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>nl.dantevg</groupId>
 	<artifactId>WebStats</artifactId>
-	<version>1.9.1</version>
+	<version>1.9.1-SNAPSHOT</version>
 
 	<properties>
 		<maven.compiler.source>8</maven.compiler.source>
@@ -30,6 +30,10 @@
 		<repository>
 			<id>placeholderapi-repo</id>
 			<url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+		</repository>
+		<repository>
+			<id>skinsrestorer-repo</id>
+			<url>https://repo.codemc.org/repository/maven-public/</url>
 		</repository>
 	</repositories>
 
@@ -94,6 +98,12 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-csv</artifactId>
 			<version>1.9.0</version>
+		</dependency>
+		<dependency>
+			<groupId>net.skinsrestorer</groupId>
+			<artifactId>skinsrestorer-api</artifactId>
+			<version>14.2.12</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/nl/dantevg/webstats/SkinsRestorerHelper.java
+++ b/src/main/java/nl/dantevg/webstats/SkinsRestorerHelper.java
@@ -2,10 +2,51 @@ package nl.dantevg.webstats;
 
 import net.skinsrestorer.api.SkinsRestorerAPI;
 import net.skinsrestorer.api.property.IProperty;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.jetbrains.annotations.Nullable;
 
-public class SkinsRestorerHelper {
-	public static @Nullable String getSkinID(String name) {
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class SkinsRestorerHelper implements Listener {
+	private Map<String, String> skins = new HashMap<>();
+	
+	public SkinsRestorerHelper(WebStats plugin) {
+		Bukkit.getServer().getPluginManager().registerEvents(this, plugin);
+	}
+	
+	@EventHandler
+	public void onPlayerJoin(PlayerJoinEvent event) {
+		String name = event.getPlayer().getName();
+		if (!skins.containsKey(name)) {
+			Bukkit.getScheduler().runTaskAsynchronously(
+					WebStats.getPlugin(WebStats.class),
+					() -> skins.put(name, getSkinIDUncached(name)));
+		}
+	}
+	
+	public @Nullable String getSkinID(String name) {
+		if (skins.containsKey(name)) {
+			return skins.get(name);
+		} else {
+			return getSkinIDUncached(name);
+		}
+	}
+	
+	public Map<String, String> getSkinIDsForPlayers(Set<String> names) {
+		Map<String, String> skins = new HashMap<>();
+		for (String entry : names) {
+			skins.put(entry, WebStats.skinsRestorerHelper.getSkinID(entry));
+		}
+		return skins;
+	}
+	
+	// Should not be called on main server thread to avoid lag!
+	private static @Nullable String getSkinIDUncached(String name) {
 		SkinsRestorerAPI skinsRestorer = SkinsRestorerAPI.getApi();
 		IProperty profile = skinsRestorer.getSkinData(name);
 		return (profile != null) ? skinsRestorer.getSkinTextureUrlStripped(profile) : null;

--- a/src/main/java/nl/dantevg/webstats/SkinsRestorerHelper.java
+++ b/src/main/java/nl/dantevg/webstats/SkinsRestorerHelper.java
@@ -1,0 +1,13 @@
+package nl.dantevg.webstats;
+
+import net.skinsrestorer.api.SkinsRestorerAPI;
+import net.skinsrestorer.api.property.IProperty;
+import org.jetbrains.annotations.Nullable;
+
+public class SkinsRestorerHelper {
+	public static @Nullable String getSkinID(String name) {
+		SkinsRestorerAPI skinsRestorer = SkinsRestorerAPI.getApi();
+		IProperty profile = skinsRestorer.getSkinData(name);
+		return (profile != null) ? skinsRestorer.getSkinTextureUrlStripped(profile) : null;
+	}
+}

--- a/src/main/java/nl/dantevg/webstats/StatData.java
+++ b/src/main/java/nl/dantevg/webstats/StatData.java
@@ -7,9 +7,11 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
+import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -20,16 +22,27 @@ public class StatData {
 	public Stats stats;
 	public Set<String> playernames;
 	public Map<String, Object> units = WebStatsConfig.getInstance().columnUnits;
+	public Map<String, String> skins;
 	
 	public StatData(Map<String, Object> online, Stats stats) {
 		this.online = online;
 		this.stats = stats;
+		addTextureIDs();
 	}
 	
 	public StatData(Map<String, Object> online, Stats stats, Set<String> playernames) {
 		this.online = online;
 		this.stats = stats;
 		this.playernames = playernames;
+		addTextureIDs();
+	}
+	
+	private void addTextureIDs() {
+		if (Bukkit.getPluginManager().getPlugin("SkinsRestorer") == null) return;
+		skins = new HashMap<>();
+		for (String entry : stats.entries) {
+			skins.put(entry, SkinsRestorerHelper.getSkinID(entry));
+		}
 	}
 	
 	@Override

--- a/src/main/java/nl/dantevg/webstats/StatData.java
+++ b/src/main/java/nl/dantevg/webstats/StatData.java
@@ -24,25 +24,11 @@ public class StatData {
 	public Map<String, Object> units = WebStatsConfig.getInstance().columnUnits;
 	public Map<String, String> skins;
 	
-	public StatData(Map<String, Object> online, Stats stats) {
-		this.online = online;
-		this.stats = stats;
-		addTextureIDs();
-	}
-	
-	public StatData(Map<String, Object> online, Stats stats, Set<String> playernames) {
+	public StatData(Map<String, Object> online, Stats stats, Set<String> playernames, Map<String, String> skins) {
 		this.online = online;
 		this.stats = stats;
 		this.playernames = playernames;
-		addTextureIDs();
-	}
-	
-	private void addTextureIDs() {
-		if (Bukkit.getPluginManager().getPlugin("SkinsRestorer") == null) return;
-		skins = new HashMap<>();
-		for (String entry : stats.entries) {
-			skins.put(entry, SkinsRestorerHelper.getSkinID(entry));
-		}
+		this.skins = skins;
 	}
 	
 	@Override

--- a/src/main/java/nl/dantevg/webstats/WebStats.java
+++ b/src/main/java/nl/dantevg/webstats/WebStats.java
@@ -37,6 +37,7 @@ public class WebStats extends JavaPlugin {
 	public static Logger logger;
 	public static FileConfiguration config;
 	public static boolean hasEssentials;
+	public static SkinsRestorerHelper skinsRestorerHelper;
 	
 	// Gets run when the plugin is enabled on server startup
 	@Override
@@ -87,6 +88,10 @@ public class WebStats extends JavaPlugin {
 			}
 		}
 		
+		if (Bukkit.getPluginManager().getPlugin("SkinsRestorer") != null) {
+			skinsRestorerHelper = new SkinsRestorerHelper(this);
+		}
+		
 		try {
 			if (configData.useHTTPS) {
 				webserver = new HTTPSWebServer();
@@ -116,6 +121,7 @@ public class WebStats extends JavaPlugin {
 		
 		scoreboardSource = null;
 		statExporter = null;
+		skinsRestorerHelper = null;
 		
 		// Let sources close connections
 		if (databaseSource != null) {

--- a/src/main/java/nl/dantevg/webstats/WebStatsConfig.java
+++ b/src/main/java/nl/dantevg/webstats/WebStatsConfig.java
@@ -2,7 +2,6 @@ package nl.dantevg.webstats;
 
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
-import org.bukkit.configuration.ConfigurationSection;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -32,6 +31,7 @@ public class WebStatsConfig {
 	public final @Nullable List<String> columns;
 	
 	public final @NotNull List<String> serverColumns;
+	public final @Nullable String serverName;
 	public final @NotNull List<TableConfig> tables;
 	public final @NotNull Map<String, Object> columnUnits;
 	
@@ -54,6 +54,7 @@ public class WebStatsConfig {
 		
 		columns = WebStats.config.getStringList("columns");
 		serverColumns = WebStats.config.getStringList("server-columns");
+		serverName = WebStats.config.getString("server-name");
 		if (WebStats.config.isConfigurationSection("column-units")) {
 			columnUnits = WebStats.config.getConfigurationSection("column-units").getValues(true);
 		} else {

--- a/src/main/java/nl/dantevg/webstats/placeholder/PlaceholderSource.java
+++ b/src/main/java/nl/dantevg/webstats/placeholder/PlaceholderSource.java
@@ -118,6 +118,13 @@ public class PlaceholderSource {
 				}
 			}
 		});
+		
+		if (WebStatsConfig.getInstance().serverName != null) {
+			String rawServerName = WebStatsConfig.getInstance().serverName;
+			String serverName = getPlaceholderForServer(rawServerName);
+			values.put("#server", "Player", (serverName != null) ? serverName : rawServerName);
+		}
+		
 		return values;
 	}
 	

--- a/src/main/java/nl/dantevg/webstats/webserver/HTTPConnection.java
+++ b/src/main/java/nl/dantevg/webstats/webserver/HTTPConnection.java
@@ -12,6 +12,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.logging.Level;
 
 public class HTTPConnection {
@@ -81,6 +83,19 @@ public class HTTPConnection {
 		ByteStreams.copy(input, output);
 		input.close();
 		output.close();
+	}
+	
+	public void sendServerIcon() throws IOException {
+		try (InputStream input = Files.newInputStream(Paths.get("server-icon.png"))) {
+			// Send headers and data
+			setHeaders("image/png");
+			exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, input.available());
+			OutputStream output = exchange.getResponseBody();
+			ByteStreams.copy(input, output);
+			output.close();
+		} catch (IOException e) {
+			sendEmptyStatus(HttpURLConnection.HTTP_NOT_FOUND);
+		}
 	}
 	
 }

--- a/src/main/java/nl/dantevg/webstats/webserver/HTTPRequestHandler.java
+++ b/src/main/java/nl/dantevg/webstats/webserver/HTTPRequestHandler.java
@@ -38,6 +38,7 @@ public class HTTPRequestHandler implements HttpHandler {
 			resources.put("/style.css", "text/css");
 			resources.put("/WebStats-dist.js", "application/javascript");
 			resources.put("/WebStats-dist.js.map", "application/json");
+			resources.put("/server-icon.png", "image/png");
 			
 			WebStatsConfig.getInstance().additionalResources.forEach(path ->
 					resources.put("/" + path, URLConnection.guessContentTypeFromName(path)));
@@ -116,7 +117,11 @@ public class HTTPRequestHandler implements HttpHandler {
 				break;
 			default:
 				if (resources.containsKey(path)) {
-					httpConnection.sendFile(resources.get(path), "web" + path);
+					if (path.equals("/server-icon.png")) {
+						httpConnection.sendServerIcon();
+					} else {
+						httpConnection.sendFile(resources.get(path), "web" + path);
+					}
 				} else {
 					WebStats.logger.log(Level.CONFIG, "Got request for " + path + ", not found");
 					httpConnection.sendEmptyStatus(HttpURLConnection.HTTP_NOT_FOUND);

--- a/src/main/java/nl/dantevg/webstats/webserver/HTTPRequestHandler.java
+++ b/src/main/java/nl/dantevg/webstats/webserver/HTTPRequestHandler.java
@@ -7,7 +7,6 @@ import nl.dantevg.webstats.StatData;
 import nl.dantevg.webstats.Stats;
 import nl.dantevg.webstats.WebStats;
 import nl.dantevg.webstats.WebStatsConfig;
-import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -17,7 +16,6 @@ import java.net.InetAddress;
 import java.net.URLConnection;
 import java.nio.file.Files;
 import java.util.*;
-import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 
 public class HTTPRequestHandler implements HttpHandler {
@@ -86,20 +84,10 @@ public class HTTPRequestHandler implements HttpHandler {
 			case "/stats.json":
 				InetAddress ip = exchange.getRemoteAddress().getAddress();
 				try {
-					// Stats need to be gathered on the main thread,
-					// see https://github.com/Dantevg/WebStats/issues/52
-					StatData stats = Bukkit.getScheduler().callSyncMethod(
-							WebStats.getPlugin(WebStats.class),
-							() -> Stats.getAll(ip)).get();
+					StatData stats = Stats.getAll(ip);
 					httpConnection.sendJson(new Gson().toJson(stats));
 				} catch (InterruptedException ignored) {
 					// do nothing
-				} catch (ExecutionException e) {
-					if (e.getCause() instanceof IOException) {
-						throw (IOException) e.getCause();
-					} else {
-						throw new RuntimeException(e);
-					}
 				}
 				break;
 			case "/online.json":

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -27,6 +27,10 @@ tables:
 # separate 'Server' row.
 server-columns: []
 
+# When displaying the server row defined above, use this name instead of "Server".
+# You can use PlaceholderAPI placeholders here. (uncomment to use)
+#server-name: ""
+
 # Specify the unit in which data from a column is *stored*. WebStats will use
 # this information to automatically adjust the *displayed* units.
 # Units you can use here:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ api-version: 1.13
 description: Display the scoreboard, PlaceholderAPI and other plugin statistics on the web
 author: RedPolygon
 website: dantevg.nl/mods-plugins/WebStats
-softdepend: [Essentials, PlaceholderAPI]
+softdepend: [Essentials, PlaceholderAPI, SkinsRestorer]
 commands:
   webstats:
     description: WebStats command

--- a/src/main/resources/web/style.css
+++ b/src/main/resources/web/style.css
@@ -49,7 +49,7 @@ tr.current-player td:not(.empty) {
 td:not(.empty) {
 	position: relative;
 	height: 50px;
-	padding: 0px 30px;
+	padding: 0px 20px;
 	background: var(--bg1);
 	text-align: right;
 	white-space: nowrap;
@@ -60,6 +60,10 @@ td:not(.empty) {
 td:not(.empty)[data-objective=Player] {
 	text-align: left;
 	padding-left: 40px;
+}
+
+td:not(.empty)[data-objective=Player][title="#server"] {
+	padding-left: 20px;
 }
 
 td:not(.empty)::after {
@@ -111,6 +115,10 @@ html.compact td:not(.empty){
 
 html.compact td:not(.empty)[data-objective=Player]{
 	padding-left: 32px;
+}
+
+html.compact td:not(.empty)[data-objective=Player][title="#server"] {
+	padding-left: 10px;
 }
 
 html.compact td.skin img {
@@ -173,6 +181,10 @@ html.compact th.webstats-sort-column::after {
 
 html.compact .status {
 	left: 11px;
+}
+
+td[title="#server"] .status {
+	display: none;
 }
 
 .status.online {

--- a/src/main/resources/web/style.css
+++ b/src/main/resources/web/style.css
@@ -92,17 +92,29 @@ td.skin img {
 	transition: width 0.2s;
 }
 
+td.skin img[title="#server"] {
+	/* Disable pixelated rendering for server icon (probably better most of the time) */
+	image-rendering: auto;
+}
+
+td.skin[title="#server"] {
+	/* "Console" image */
+	background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAPElEQVQ4T2NUUlL6z0ABYBw1gGE0DBioHAZ3795lUFZWJildosQCRQaQoxnkVLgL0A2A8dFpdP8NfEICAMkiK2HeQ9JUAAAAAElFTkSuQmCC");
+	background-size: cover;
+	image-rendering: pixelated;
+}
+
 html.compact td:not(.empty){
-	height: 30px;
+	height: 32px;
 	padding: 0px 10px;
 }
 
 html.compact td:not(.empty)[data-objective=Player]{
-	padding-left: 30px;
+	padding-left: 32px;
 }
 
 html.compact td.skin img {
-	width: 30px;
+	width: 32px;
 }
 
 .sticky {
@@ -149,7 +161,7 @@ html.compact th.webstats-sort-column::after {
 
 .status {
 	position: absolute;
-	top: 20px;
+	top: calc(50% - 5px);
 	left: 15px;
 	width: 10px;
 	height: 10px;
@@ -159,9 +171,8 @@ html.compact th.webstats-sort-column::after {
 	transition: top 0.2s, left 0.2s;
 }
 
-html.compact .status{
-	top: 10px;
-	left: 10px;
+html.compact .status {
+	left: 11px;
 }
 
 .status.online {

--- a/web/example/style.css
+++ b/web/example/style.css
@@ -49,7 +49,7 @@ tr.current-player td:not(.empty) {
 td:not(.empty) {
 	position: relative;
 	height: 50px;
-	padding: 0px 30px;
+	padding: 0px 20px;
 	background: var(--bg1);
 	text-align: right;
 	white-space: nowrap;
@@ -60,6 +60,10 @@ td:not(.empty) {
 td:not(.empty)[data-objective=Player] {
 	text-align: left;
 	padding-left: 40px;
+}
+
+td:not(.empty)[data-objective=Player][title="#server"] {
+	padding-left: 20px;
 }
 
 td:not(.empty)::after {
@@ -111,6 +115,10 @@ html.compact td:not(.empty){
 
 html.compact td:not(.empty)[data-objective=Player]{
 	padding-left: 32px;
+}
+
+html.compact td:not(.empty)[data-objective=Player][title="#server"] {
+	padding-left: 10px;
 }
 
 html.compact td.skin img {
@@ -173,6 +181,10 @@ html.compact th.webstats-sort-column::after {
 
 html.compact .status {
 	left: 11px;
+}
+
+td[title="#server"] .status {
+	display: none;
 }
 
 .status.online {

--- a/web/example/style.css
+++ b/web/example/style.css
@@ -92,17 +92,29 @@ td.skin img {
 	transition: width 0.2s;
 }
 
+td.skin img[title="#server"] {
+	/* Disable pixelated rendering for server icon (probably better most of the time) */
+	image-rendering: auto;
+}
+
+td.skin[title="#server"] {
+	/* "Console" image */
+	background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAPElEQVQ4T2NUUlL6z0ABYBw1gGE0DBioHAZ3795lUFZWJildosQCRQaQoxnkVLgL0A2A8dFpdP8NfEICAMkiK2HeQ9JUAAAAAElFTkSuQmCC");
+	background-size: cover;
+	image-rendering: pixelated;
+}
+
 html.compact td:not(.empty){
-	height: 30px;
+	height: 32px;
 	padding: 0px 10px;
 }
 
 html.compact td:not(.empty)[data-objective=Player]{
-	padding-left: 30px;
+	padding-left: 32px;
 }
 
 html.compact td.skin img {
-	width: 30px;
+	width: 32px;
 }
 
 .sticky {
@@ -149,7 +161,7 @@ html.compact th.webstats-sort-column::after {
 
 .status {
 	position: absolute;
-	top: 20px;
+	top: calc(50% - 5px);
 	left: 15px;
 	width: 10px;
 	height: 10px;
@@ -159,9 +171,8 @@ html.compact th.webstats-sort-column::after {
 	transition: top 0.2s, left 0.2s;
 }
 
-html.compact .status{
-	top: 10px;
-	left: 10px;
+html.compact .status {
+	left: 11px;
 }
 
 .status.online {

--- a/web/src/Connection.ts
+++ b/web/src/Connection.ts
@@ -3,12 +3,14 @@ export default class Connection {
 	scores: string
 	online: string
 	tables: string
+	serverIcon: string
 
-	constructor({ all, scores, online, tables }) {
+	constructor({ all, scores, online, tables, serverIcon }) {
 		this.all = all
 		this.scores = scores
 		this.online = online
 		this.tables = tables
+		this.serverIcon = serverIcon
 	}
 
 	static json(host: string) {
@@ -19,6 +21,7 @@ export default class Connection {
 			scores: `${protocol}${host}/scoreboard.json`,
 			online: `${protocol}${host}/online.json`,
 			tables: `${protocol}${host}/tables.json`,
+			serverIcon: `${protocol}${host}/server-icon.png`,
 		})
 	}
 

--- a/web/src/Data.ts
+++ b/web/src/Data.ts
@@ -16,6 +16,7 @@ export default class Data {
 	players: Online
 	columns_: { [column: string]: number }
 	units: { [column: string]: string }
+	skins: { [player: string]: string }
 	playernames: string[]
 
 	constructor(data: { scoreboard: Scoreboard, online: Online, playernames: string[] }) {
@@ -57,11 +58,13 @@ export default class Data {
 	setOnlineStatus(online: Online) { this.players = online }
 	setPlayernames(playernames: string[]) { this.playernames = playernames }
 	setUnits(units: { [column: string]: string }) { this.units = units }
-	setStats(data: { scoreboard: Scoreboard, online: Online, playernames: string[], units?: { [column: string]: string } }) {
+	setSkins(skins: { [player: string]: string }) { this.skins = skins }
+	setStats(data: { scoreboard: Scoreboard, online: Online, playernames: string[], units?: { [column: string]: string }, skins?: { [player: string]: string } }) {
 		this.setScoreboard(data.scoreboard)
 		this.setOnlineStatus(data.online)
 		this.setPlayernames(data.playernames)
 		this.setUnits(data.units ?? {})
+		this.setSkins(data.skins ?? {})
 	}
 
 	filter() {

--- a/web/src/Data.ts
+++ b/web/src/Data.ts
@@ -27,7 +27,7 @@ export default class Data {
 	get online() { return this.players }
 	get nOnline() { return Object.keys(this.players).length }
 
-	isOnline = (player: string) => this.players[player] === true
+	isOnline = (player: string) => this.players[player] === true || player == "#server"
 	isAFK = (player: string) => this.players[player] === "afk"
 	isOffline = (player: string) => !!this.players[player]
 	getStatus = (player: string): PlayerStatus => this.isOnline(player) ? "online"

--- a/web/src/Display.tsx
+++ b/web/src/Display.tsx
@@ -41,6 +41,7 @@ export default class Display {
 				columns: this.columns ?? this.data.columns,
 				units: this.data.units,
 				showSkins: this.showSkins,
+				skin: this.data.skins[entry],
 				entry,
 				isCurrentPlayer: this.data.isCurrentPlayer(entry)
 			}))

--- a/web/src/Display.tsx
+++ b/web/src/Display.tsx
@@ -11,18 +11,20 @@ export default class Display {
 	sortColumn: string
 	descending: boolean
 	showSkins: boolean
+	serverIconURL: string
 	hideOffline: boolean
 
 	data: Data
 	rows: Map<string, Row>
 
-	constructor({ table, pagination, showSkins = true }, { columns, sortColumn = "Player", sortDirection = "descending" }: TableConfig) {
+	constructor({ table, pagination, showSkins = true, serverIconURL }, { columns, sortColumn = "Player", sortDirection = "descending" }: TableConfig) {
 		this.table = table
 		this.pagination = pagination
 		this.columns = columns
 		this.sortColumn = sortColumn
 		this.descending = sortDirection == "descending"
 		this.showSkins = showSkins
+		this.serverIconURL = serverIconURL
 		this.hideOffline = false
 
 		if (this.pagination) this.pagination.onPageChange = (page) => this.show()
@@ -41,7 +43,7 @@ export default class Display {
 				columns: this.columns ?? this.data.columns,
 				units: this.data.units,
 				showSkins: this.showSkins,
-				skin: this.data.skins[entry],
+				skin: (entry == "#server") ? this.serverIconURL : this.data.skins[entry],
 				entry,
 				isCurrentPlayer: this.data.isCurrentPlayer(entry)
 			}))

--- a/web/src/Display.tsx
+++ b/web/src/Display.tsx
@@ -74,7 +74,7 @@ export default class Display {
 	}
 
 	updateScoreboard() {
-		for (const column of this.columns ?? this.data.columns) {
+		for (const column of ["Player"].concat(this.columns ?? this.data.columns)) {
 			let max = 0
 			let isNumberColumn = true
 

--- a/web/src/Display.tsx
+++ b/web/src/Display.tsx
@@ -78,6 +78,8 @@ export default class Display {
 
 	updateScoreboard() {
 		for (const column of ["Player"].concat(this.columns ?? this.data.columns)) {
+			if (column == "Player" && this.data.columns_.Player == 1) continue;
+			
 			let max = 0
 			let isNumberColumn = true
 

--- a/web/src/Table.tsx
+++ b/web/src/Table.tsx
@@ -58,10 +58,10 @@ const Cell = ({ column, value, relative, unit }: { column: string, value: string
 	</td>
 }
 
-const PlayerCell = ({ entry, status }: { entry: string, status: PlayerStatus }) => (
-	<td data-objective="Player" data-value={entry}>
+const PlayerCell = ({ entry, status, name }: { entry: string, status: PlayerStatus, name?: string }) => (
+	<td data-objective="Player" data-value={entry} title={entry}>
 		<div className={["status", status]} title={status}></div>
-		{transformEntryName(entry)}
+		<>{name ? convertFormattingCodes(name) : transformEntryName(entry)}</>
 	</td>
 )
 
@@ -85,7 +85,7 @@ export class Row extends Component {
 	render = () => (
 		<tr entry={this.props.entry} className={[this.status, this.props.isCurrentPlayer ? "current-player" : undefined]}>
 			{this.props.showSkins && <Avatar entry={this.props.entry} />}
-			<PlayerCell entry={this.props.entry} status={this.status} />
+			<PlayerCell entry={this.props.entry} status={this.status} name={this.values.get("Player")} />
 			{...this.props.columns.map(column => <Cell column={column} value={this.values.get(column)} relative={this.relative.get(column)} unit={this.props.units[column]} />)}
 		</tr>
 	)

--- a/web/src/Table.tsx
+++ b/web/src/Table.tsx
@@ -27,6 +27,16 @@ const transformEntryName = (entry: string) => {
 	else return entry
 }
 
+const getSkin = (entry: string, skin?: string) => {
+	if (skin != undefined && skin.startsWith("http")) {
+		return skin
+	} else if (skin != undefined) {
+		return `https://www.mc-heads.net/avatar/${skin}/64.png`
+	} else if (entry != "#server") {
+		return `https://www.mc-heads.net/avatar/${entry}/64.png`
+	}
+}
+
 export const Heading = ({ columns, showSkins, sortColumn, sortDescending, onClick }: HeadingData) => (
 	<tr>
 		<th colSpan={showSkins && 2} onClick={onClick} onKeyDown={onKeyDown} tabIndex="0" data-objective="Player" className={columnClass("Player", sortColumn, sortDescending)}>
@@ -38,10 +48,8 @@ export const Heading = ({ columns, showSkins, sortColumn, sortDescending, onClic
 	</tr>)
 
 const Avatar = ({ entry, skin }: { entry: string, skin?: string }) => (
-	<td className={["sticky", "skin"]}>
-		<img
-			title={entry}
-			src={skin ? `https://www.mc-heads.net/avatar/${skin}.png` : (entry == "#server" ? CONSOLE_IMAGE : `https://www.mc-heads.net/avatar/${entry}.png`)} />
+	<td className={["sticky", "skin"]} title={entry}>
+		<img title={entry} src={getSkin(entry, skin)} alt=" " />
 	</td>
 )
 
@@ -69,7 +77,7 @@ type RowData = {
 	columns: string[]
 	units: { [column: string]: string }
 	showSkins: boolean
-	skin?: string,
+	skin?: string
 	entry: string
 	isCurrentPlayer: boolean
 }

--- a/web/src/Table.tsx
+++ b/web/src/Table.tsx
@@ -37,11 +37,11 @@ export const Heading = ({ columns, showSkins, sortColumn, sortDescending, onClic
 		</th>)}
 	</tr>)
 
-const Avatar = ({ entry }: { entry: string }) => (
+const Avatar = ({ entry, skin }: { entry: string, skin?: string }) => (
 	<td className={["sticky", "skin"]}>
 		<img
 			title={entry}
-			src={entry == "#server" ? CONSOLE_IMAGE : `https://www.mc-heads.net/avatar/${entry}.png`} />
+			src={skin ? `https://www.mc-heads.net/avatar/${skin}.png` : (entry == "#server" ? CONSOLE_IMAGE : `https://www.mc-heads.net/avatar/${entry}.png`)} />
 	</td>
 )
 
@@ -69,6 +69,7 @@ type RowData = {
 	columns: string[]
 	units: { [column: string]: string }
 	showSkins: boolean
+	skin?: string,
 	entry: string
 	isCurrentPlayer: boolean
 }
@@ -84,7 +85,7 @@ export class Row extends Component {
 
 	render = () => (
 		<tr entry={this.props.entry} className={[this.status, this.props.isCurrentPlayer ? "current-player" : undefined]}>
-			{this.props.showSkins && <Avatar entry={this.props.entry} />}
+			{this.props.showSkins && <Avatar entry={this.props.entry} skin={this.props.skin} />}
 			<PlayerCell entry={this.props.entry} status={this.status} name={this.values.get("Player")} />
 			{...this.props.columns.map(column => <Cell column={column} value={this.values.get(column)} relative={this.relative.get(column)} unit={this.props.units[column]} />)}
 		</tr>

--- a/web/src/WebStats.ts
+++ b/web/src/WebStats.ts
@@ -158,7 +158,7 @@ export default class WebStats {
 			pagination = new Pagination(config.displayCount, paginationParent)
 		}
 		this.displays.push(new Display(
-			{ ...config, table: config.tables[tableConfig.name ?? ""].table, pagination: pagination },
+			{ ...config, table: config.tables[tableConfig.name ?? ""].table, pagination: pagination, serverIconURL: this.connection.serverIcon },
 			tableConfig
 		))
 	}
@@ -183,7 +183,7 @@ export default class WebStats {
 			.appendChild(document.createElement("table"))
 		if (tableConfig.name) tableElem.setAttribute("webstats-table", tableConfig.name)
 		this.displays.push(new Display(
-			{ ...config, table: tableElem, pagination: pagination },
+			{ ...config, table: tableElem, pagination: pagination, serverIconURL: this.connection.serverIcon },
 			tableConfig
 		))
 	}


### PR DESCRIPTION
- [x] Add a separate `server-name` config item next to `server-columns` where you can use placeholders. This will replace the server's name in the first column (currently "Server").
- [x] Display the server's icon from the server list as the server's "player-head."
- [ ] For tables that only display the server's stats and not also player's stats, change the first column's name from "Player" to "Name" (I'm not sure about this one).
- [x] While at it, display the server's status as "online" or disable the status indicator, because it can never be afk or offline.
- [x] Integrate SkinsRestorer